### PR TITLE
Add signWithSHA128:error: and verifySignatureWithSHA128:message:

### DIFF
--- a/MIHCrypto/Core/MIHPrivateKey.h
+++ b/MIHCrypto/Core/MIHPrivateKey.h
@@ -36,6 +36,16 @@
 - (NSData *)decrypt:(NSData *)cipher error:(NSError **)error;
 
 /**
+ * Signs the passed data. SHA128 is used to create the hash of the message.
+ *
+ * @param message The message to sign.
+ * @param error   Reference used to return an error if there something went wrong.
+ *
+ * @return The created signature or nil if any error occurred.
+ */
+- (NSData *)signWithSHA128:(NSData *)message error:(NSError **)error;
+
+/**
  * Signs the passed data. SHA256 is used to create the hash of the message.
  *
  * @param message The message to sign.

--- a/MIHCrypto/Core/MIHPublicKey.h
+++ b/MIHCrypto/Core/MIHPublicKey.h
@@ -36,6 +36,15 @@
 - (NSData *)encrypt:(NSData *)message error:(NSError **)error;
 
 /**
+ * Verifies the signature of the passed message. SHA128 is used to create the hash of the message.
+ *
+ * @param signature The signature bytes to verify.
+ * @param message The message to verify.
+ * @return YES if the signature is valid.
+ */
+- (BOOL)verifySignatureWithSHA128:(NSData *)signature message:(NSData *)message;
+
+/**
  * Verifies the signature of the passed message. SHA256 is used to create the hash of the message.
  *
  * @param signature The signature bytes to verify.

--- a/MIHCrypto/RSA/MIHRSAPublicKey.m
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.m
@@ -133,6 +133,25 @@
     return cipherData;
 }
 
+- (BOOL)verifySignatureWithSHA128:(NSData *)signature message:(NSData *)message
+{
+    SHA_CTX shaCtx;
+    unsigned char messageDigest[SHA_DIGEST_LENGTH];
+    if(!SHA_Init(&shaCtx)) {
+        return NO;
+    }
+    if (!SHA_Update(&shaCtx, message.bytes, message.length)) {
+        return NO;
+    }
+    if (!SHA_Final(messageDigest, &shaCtx)) {
+        return NO;
+    }
+    if (RSA_verify(NID_sha, messageDigest, SHA_DIGEST_LENGTH, signature.bytes, (int)signature.length, _rsa) == 0) {
+        return NO;
+    }
+    return YES;
+}
+
 - (BOOL)verifySignatureWithSHA256:(NSData *)signature message:(NSData *)message
 {
     SHA256_CTX sha256Ctx;

--- a/MIHCryptoTests/RSA/MIHRSAKeyTests.m
+++ b/MIHCryptoTests/RSA/MIHRSAKeyTests.m
@@ -80,6 +80,21 @@
     XCTAssertEqual(NO, isVerified);
 }
 
+- (void)testSignAndVerifyUsingSHA1
+{
+    NSError *signingError = nil;
+    NSData *signatureData = [self.privateKey signWithSHA128:self.messageData error:&signingError];
+    XCTAssertNil(signingError);
+    BOOL isVerified = [self.publicKey verifySignatureWithSHA128:signatureData message:self.messageData];
+    XCTAssertEqual(YES, isVerified);
+}
+
+- (void)testInvalidSignatureUsingSHA1
+{
+    BOOL isVerified = [self.publicKey verifySignatureWithSHA128:self.messageData message:self.messageData];
+    XCTAssertEqual(NO, isVerified);
+}
+
 - (void)testDataValue
 {
     XCTAssertEqualObjects(self.pub, self.publicKey.dataValue);


### PR DESCRIPTION
Needed to sign some data using SHA1 hashing, but it was not implemented :(
I have added two methods to sign and verify on MIHRSAPrivateKey and MIHRSAPublicKey which uses SHA1 hashing.

```
- (BOOL)verifySignatureWithSHA128:(NSData *)signature message:(NSData *)message;
- (NSData *)signWithSHA128:(NSData *)message error:(NSError **)error;
```
