### PR TITLE
Fix calculating hash bug in signWithSHA128:error:

### DIFF
--- a/MIHCrypto/RSA/MIHRSAPrivateKey.m
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.m
@@ -117,22 +117,22 @@
 {
     SHA_CTX shaCtx;
     unsigned char messageDigest[SHA_DIGEST_LENGTH];
-    if (!SHA_Init(&shaCtx)) {
+    if (!SHA1_Init(&shaCtx)) {
         *error = [NSError errorFromOpenSSL];
         return nil;
     }
-    if (!SHA_Update(&shaCtx, message.bytes, message.length)) {
+    if (!SHA1_Update(&shaCtx, message.bytes, message.length)) {
         *error = [NSError errorFromOpenSSL];
         return nil;
     }
-    if (!SHA_Final(messageDigest, &shaCtx)) {
+    if (!SHA1_Final(messageDigest, &shaCtx)) {
         *error = [NSError errorFromOpenSSL];
         return nil;
     }
 
     NSMutableData *signature = [NSMutableData dataWithLength:(NSUInteger) RSA_size(_rsa)];
     unsigned int signatureLength = 0;
-    if (RSA_sign(NID_sha, messageDigest, SHA_DIGEST_LENGTH, signature.mutableBytes, &signatureLength, _rsa) == 0) {
+    if (RSA_sign(NID_sha1, messageDigest, SHA_DIGEST_LENGTH, signature.mutableBytes, &signatureLength, _rsa) == 0) {
         *error = [NSError errorFromOpenSSL];
         return nil;
     }

--- a/MIHCrypto/RSA/MIHRSAPublicKey.m
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.m
@@ -137,16 +137,16 @@
 {
     SHA_CTX shaCtx;
     unsigned char messageDigest[SHA_DIGEST_LENGTH];
-    if(!SHA_Init(&shaCtx)) {
+    if(!SHA1_Init(&shaCtx)) {
         return NO;
     }
-    if (!SHA_Update(&shaCtx, message.bytes, message.length)) {
+    if (!SHA1_Update(&shaCtx, message.bytes, message.length)) {
         return NO;
     }
-    if (!SHA_Final(messageDigest, &shaCtx)) {
+    if (!SHA1_Final(messageDigest, &shaCtx)) {
         return NO;
     }
-    if (RSA_verify(NID_sha, messageDigest, SHA_DIGEST_LENGTH, signature.bytes, (int)signature.length, _rsa) == 0) {
+    if (RSA_verify(NID_sha1, messageDigest, SHA_DIGEST_LENGTH, signature.bytes, (int)signature.length, _rsa) == 0) {
         return NO;
     }
     return YES;


### PR DESCRIPTION
In my previous commit I used SHA_\* functions to calculate the SHA128 hash and it is wrong. SHA_\* functions calculates the SHA-0 which is the direct ancestor of SHA-1 and is an obsolete algorithm. I have changed it to use SHA1_\* functions which correctly calculates SHA1 hash.
