### PR TITLE
Add missing initialization methods to MIHBigInteger

### DIFF
--- a/MIHCrypto/Mathematics/MIHBigInteger.h
+++ b/MIHCrypto/Mathematics/MIHBigInteger.h
@@ -40,6 +40,15 @@
 - (id)initWithUnsignedInteger:(BN_ULONG)value;
 
 /**
+ *  Initialises MIHBigInteger with the passed NSInteger value.
+ *
+ *  @param value The value of to get assigned to the BigNum.
+ *
+ *  @return The newly-created MIHBigInteger instance.
+ */
+- (id)initWithSignedInteger:(BN_LONG)value;
+
+/**
  *  Initialises MIHBigInteger with the passed NSString which contains a decimal number as string.
  *
  *  @param decimalString NSString which contains a decimal number represented by chars.

--- a/MIHCrypto/Mathematics/MIHBigInteger.m
+++ b/MIHCrypto/Mathematics/MIHBigInteger.m
@@ -39,6 +39,23 @@
     return self;
 }
 
+- (id)initWithSignedInteger:(BN_LONG)value
+{
+    self = [super init];
+    if (self) {
+        _representedBn = BN_new();
+        if (!_representedBn) {
+            @throw [NSException openSSLException];
+        }
+        BN_set_word(_representedBn, ABS(value));
+        if (value < 0) {
+            BN_set_negative(_representedBn, 1);
+        }
+    }
+
+    return self;
+}
+
 - (id)initWithDecimalStringValue:(NSString *)decimalString
 {
     self = [super init];

--- a/MIHCryptoTests/Mathematics/MIHBigIntegerTests.m
+++ b/MIHCryptoTests/Mathematics/MIHBigIntegerTests.m
@@ -221,5 +221,14 @@
     XCTAssertEqualObjects(bigInteger.decimalStringValue, @"12345");
 }
 
+- (void)testInitWithSignedInteger
+{
+    MIHBigInteger *positiveBigInteger = [[MIHBigInteger alloc] initWithSignedInteger:12345];
+    XCTAssertEqualObjects(positiveBigInteger.decimalStringValue, @"12345");
+
+    MIHBigInteger *negativeBigInteger = [[MIHBigInteger alloc] initWithSignedInteger:-12345];
+    XCTAssertEqualObjects(negativeBigInteger.decimalStringValue, @"-12345");
+}
+
 
 @end


### PR DESCRIPTION
Initialization of MIHBigIntegers with hex string and signed ints were missing. Here is a patch with those missing initializers.

```
- (id)initWithHexStringValue:(NSString *)hexString;
- (id)initWithSignedInteger:(BN_LONG)value;
```

Also another initializer I found to be missing is initializing a new big number with raw bytes ie., `BN_bin2bn`
I saw you have used `BN_mpi2bn` in `initWithData` and that makes sense. But I would like to add an initializer which uses `BN_bin2bn` too, what do you think will be a good name for that initializer?
