### PR TITLE
Refactor MIHBigInteger#initWithData to use BN_bin2bn instead of BN_mpi2bn

### DIFF
--- a/MIHCrypto/Mathematics/MIHBigInteger.h
+++ b/MIHCrypto/Mathematics/MIHBigInteger.h
@@ -31,6 +31,15 @@
 }
 
 /**
+ *  Initialises MIHBigInteger with the passed NSData which contains 4-byte big-endian encoded number.
+ *
+ *  @param value The value of to get assigned to the BigNum.
+ *
+ *  @return The newly-created MIHBigInteger instance.
+ */
+- (id)initWithMpiData:(NSData *)value;
+
+/**
  *  Initialises MIHBigInteger with the passed NSUInteger value.
  *
  *  @param value The value of to get assigned to the BigNum.
@@ -72,6 +81,13 @@
  *  @return NSString which represents the MIHBigInteger.
  */
 - (NSString *)hexStringValue;
+
+/**
+ *  Creates a NSData of MPI representation of this MIHBigInteger.
+ *
+ *  @return NSData which represents the MIHBigInteger.
+ */
+- (NSData *)mpiDataValue;
 
 /**
  *  Compares this MIHBigInteger with the passed MIHBigInteger.

--- a/MIHCrypto/Mathematics/MIHBigInteger.m
+++ b/MIHCrypto/Mathematics/MIHBigInteger.m
@@ -113,11 +113,27 @@
         if (!_representedBn) {
             @throw [NSException openSSLException];
         }
-        if (!BN_mpi2bn(dataValue.bytes, (int)dataValue.length, _representedBn)) {
+        if (!BN_bin2bn(dataValue.bytes, (int)dataValue.length, _representedBn)) {
             @throw [NSException openSSLException];
         }
     }
-    
+
+    return self;
+}
+
+- (id)initWithMpiData:(NSData *)mpiDataValue
+{
+    self = [super init];
+    if (self) {
+        _representedBn = BN_new();
+        if (!_representedBn) {
+            @throw [NSException openSSLException];
+        }
+        if (!BN_mpi2bn(mpiDataValue.bytes, (int)mpiDataValue.length, _representedBn)) {
+            @throw [NSException openSSLException];
+        }
+    }
+
     return self;
 }
 
@@ -128,9 +144,8 @@
 
 - (NSData *)dataValue
 {
-    int expectedLength = BN_bn2mpi(_representedBn, NULL);
-    NSMutableData *data = [[NSMutableData alloc] initWithLength:expectedLength];
-    BN_bn2mpi(_representedBn, data.mutableBytes);
+    NSMutableData *data = [[NSMutableData alloc] initWithLength:BN_num_bytes(_representedBn)];
+    BN_bn2bin(_representedBn, data.mutableBytes);
     return data;
 }
 
@@ -373,6 +388,14 @@
     }
     
     return [NSString stringWithUTF8String:hexString];
+}
+
+- (NSData *)mpiDataValue
+{
+    int expectedLength = BN_bn2mpi(_representedBn, NULL);
+    NSMutableData *data = [[NSMutableData alloc] initWithLength:expectedLength];
+    BN_bn2mpi(_representedBn, data.mutableBytes);
+    return data;
 }
 
 - (BOOL)isEqualToBigInteger:(MIHBigInteger *)other

--- a/MIHCryptoTests/Mathematics/MIHBigIntegerTests.m
+++ b/MIHCryptoTests/Mathematics/MIHBigIntegerTests.m
@@ -181,7 +181,7 @@
 - (void)testMIHCoding
 {
     MIHBigInteger *someBigInteger = [[MIHBigInteger alloc] initWithDecimalStringValue:@"123456"];
-    MIHBigInteger *sameBigInteger = [[MIHBigInteger alloc] initWithData:someBigInteger.dataValue];
+    MIHBigInteger *sameBigInteger = [[MIHBigInteger alloc] initWithMpiData:someBigInteger.mpiDataValue];
     XCTAssertEqualObjects(someBigInteger, sameBigInteger);
 }
 
@@ -230,5 +230,18 @@
     XCTAssertEqualObjects(negativeBigInteger.decimalStringValue, @"-12345");
 }
 
+-(void)testInitWithMpiData
+{
+    MIHBigInteger *someBigInteger = [[MIHBigInteger alloc] initWithSignedInteger:1234];
+    MIHBigInteger *anotherBigInteger = [[MIHBigInteger alloc] initWithMpiData:someBigInteger.mpiDataValue];
+    XCTAssertEqualObjects(anotherBigInteger.decimalStringValue, @"1234");
+}
+
+-(void)testInitWithData
+{
+    MIHBigInteger *someBigInteger = [[MIHBigInteger alloc] initWithSignedInteger:1234];
+    MIHBigInteger *anotherBigInteger = [[MIHBigInteger alloc] initWithData:someBigInteger.dataValue];
+    XCTAssertEqualObjects(anotherBigInteger.decimalStringValue, @"1234");
+}
 
 @end


### PR DESCRIPTION
The current `MIHBigInteger#initWithData:` uses `BN_mpi2bn` which which doesn't seem to be the right option when there is `BN_bin2bn`, and so I refactored the method to use latter mentioned function. Also I have added `MIHBigInteger#initWithMpiData:` to add support for `BN_mpi2bn` too.