### PR TITLE
Several improvements around RSA crypto

### DIFF
--- a/MIHCrypto/Core/MIHPrivateKey.h
+++ b/MIHCrypto/Core/MIHPrivateKey.h
@@ -26,6 +26,16 @@
 @protocol MIHPrivateKey <NSObject, NSCopying, NSCoding, MIHCoding>
 
 /**
+ *  Encrypts the passed message with this private key.
+ *
+ *  @param message The message to get encrypted.
+ *  @param error   Will be set if an error occurs.
+ *
+ *  @return The encrypted cipher data or nil if an error occured.
+ */
+- (NSData *)encrypt:(NSData *)message error:(NSError **)error;
+
+/**
  *  Decrypts the passed cipher data with this private key.
  *
  *  @param cipher The cipher data to decrypt.

--- a/MIHCrypto/Core/MIHPublicKey.h
+++ b/MIHCrypto/Core/MIHPublicKey.h
@@ -36,6 +36,16 @@
 - (NSData *)encrypt:(NSData *)message error:(NSError **)error;
 
 /**
+ *  Decrypts the passed cipher data with this public key.
+ *
+ *  @param cipher The cipher data to decrypt.
+ *  @param error  Will get set if an error occurs while decrypting the cipher.
+ *
+ *  @return The encrypted message or nil if an error occured.
+ */
+- (NSData *)decrypt:(NSData *)cipher error:(NSError **)error;
+
+/**
  * Verifies the signature of the passed message. SHA128 is used to create the hash of the message.
  *
  * @param signature The signature bytes to verify.

--- a/MIHCrypto/RSA/MIHRSAPrivateKey.h
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.h
@@ -23,9 +23,11 @@
  *
  * @author <a href="http://www.michaelhohl.net">Michael Hohl</a>
  */
-@interface MIHRSAPrivateKey : NSObject<MIHPrivateKey> {
+@interface MIHRSAPrivateKey : NSObject<MIHPrivateKey>
+{
 @protected
     RSA *_rsa;
 }
+@property (nonatomic, assign) int rsaPadding;
 
 @end

--- a/MIHCrypto/RSA/MIHRSAPrivateKey.m
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.m
@@ -79,6 +79,14 @@
 #pragma mark MIHPrivateKey
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+- (int)rsaPadding
+{
+    if (_rsaPadding == 0)
+        _rsaPadding = RSA_PKCS1_OAEP_PADDING;
+
+    return _rsaPadding;
+}
+
 - (NSData *)dataValue
 {
     EVP_PKEY *pkey = EVP_PKEY_new();
@@ -99,11 +107,23 @@
     return [NSData dataWithBytesNoCopy:privateBytes length:privateBytesLength];
 }
 
+- (NSData *)encrypt:(NSData *)messageData error:(NSError **)error
+{
+    NSMutableData *cipherData = [NSMutableData dataWithLength:(NSUInteger) RSA_size(_rsa)];
+    int cipherBytesLength = RSA_private_encrypt((int)messageData.length, messageData.bytes, cipherData.mutableBytes, _rsa, self.rsaPadding);
+    if (cipherBytesLength < 0) {
+        if (error) *error = [NSError errorFromOpenSSL];
+    }
+    [cipherData setLength:(NSUInteger) cipherBytesLength];
+
+    return cipherData;
+}
+
 - (NSData *)decrypt:(NSData *)cipherData error:(NSError **)error
 {
     NSUInteger rsaSize = (NSUInteger) RSA_size(_rsa);
     NSMutableData *messageData = [NSMutableData dataWithLength:rsaSize];
-    int messageBytesLength = RSA_private_decrypt((int)cipherData.length, cipherData.bytes, messageData.mutableBytes, _rsa, RSA_PKCS1_OAEP_PADDING);
+    int messageBytesLength = RSA_private_decrypt((int)cipherData.length, cipherData.bytes, messageData.mutableBytes, _rsa, self.rsaPadding);
     if (messageBytesLength < 0) {
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;

--- a/MIHCrypto/RSA/MIHRSAPrivateKey.m
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.m
@@ -82,7 +82,7 @@
 - (int)rsaPadding
 {
     if (_rsaPadding == 0)
-        _rsaPadding = RSA_PKCS1_OAEP_PADDING;
+        _rsaPadding = RSA_PKCS1_PADDING;
 
     return _rsaPadding;
 }

--- a/MIHCrypto/RSA/MIHRSAPublicKey.h
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.h
@@ -28,5 +28,6 @@
 @protected
     RSA *_rsa;
 }
+@property (nonatomic, assign) int rsaPadding;
 
 @end

--- a/MIHCrypto/RSA/MIHRSAPublicKey.m
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.m
@@ -89,7 +89,7 @@
 - (int)rsaPadding
 {
     if (_rsaPadding == 0)
-        _rsaPadding = RSA_PKCS1_OAEP_PADDING;
+        _rsaPadding = RSA_PKCS1_PADDING;
 
     return _rsaPadding;
 }

--- a/MIHCryptoTests/RSA/MIHRSAKeyTests.m
+++ b/MIHCryptoTests/RSA/MIHRSAKeyTests.m
@@ -60,7 +60,7 @@
     self.privateKey = [[MIHRSAPrivateKey alloc] initWithData:self.pem];
 }
 
-- (void)testEncryptionAndDecryption
+- (void)testEncryptionWithPublicKeyAndDecryptionWithPrivateKey
 {
     NSError *encryptionError = nil;
     NSData *encryptedData = [self.publicKey encrypt:self.messageData error:&encryptionError];
@@ -69,6 +69,34 @@
     NSData *decryptedData = [self.privateKey decrypt:encryptedData error:&decryptionError];
     XCTAssertNil(decryptionError);
     XCTAssertEqualObjects(self.messageData, decryptedData);
+}
+
+- (void)testEncryptionWithPrivateKeyAndDecryptionWithPublicKey
+{
+    NSError *encryptionError = nil;
+    NSData *encryptedData = [self.privateKey encrypt:self.messageData error:&encryptionError];
+    XCTAssertNil(encryptionError);
+    NSError *decryptionError = nil;
+    NSData *decryptedData = [self.publicKey decrypt:encryptedData error:&decryptionError];
+    XCTAssertNil(decryptionError);
+    XCTAssertEqualObjects(self.messageData, decryptedData);
+}
+
+- (void)testRsaDefaultPadding
+{
+    XCTAssertEqual(self.privateKey.rsaPadding, RSA_PKCS1_PADDING);
+    XCTAssertEqual(self.publicKey.rsaPadding, RSA_PKCS1_PADDING);
+}
+
+- (void)testRsaPaddingChange
+{
+    self.privateKey.rsaPadding = RSA_PKCS1_OAEP_PADDING;
+    XCTAssertEqual(self.privateKey.rsaPadding, RSA_PKCS1_OAEP_PADDING);
+
+    self.publicKey.rsaPadding = RSA_PKCS1_OAEP_PADDING;
+    XCTAssertEqual(self.publicKey.rsaPadding, RSA_PKCS1_OAEP_PADDING);
+
+    [self testEncryptionWithPublicKeyAndDecryptionWithPrivateKey];
 }
 
 - (void)testSignAndVerify


### PR DESCRIPTION
Since RSA is asymmetric cryptography sometimes it is useful to have an ability to encrypt with private key and to decrypt with public key in addition to common approach. I extended MIHPrivateKey and MIHPublicKey protocols to support it in addition to MIHRSAPrivateKey and MIHRSAPublicKey updates.

Another thing is that forcing RSA_PKCS1_OAEP_PADDING is not useful for general approach. So I have added ability to customize rsa padding via special property of MIHRSAPrivateKey and MIHRSAPublicKey.