### PR TITLE
Update to OpenSSL 1.1.180

### DIFF
--- a/MIHCrypto.podspec
+++ b/MIHCrypto.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/hohl/MIHCrypto.git", :tag => "#{s.version}" }
   
 
-  s.ios.deployment_target = '6.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
 
   s.requires_arc = true
   s.static_framework = true
@@ -19,11 +19,9 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'OTHER_CFLAGS' => '-DLIBRESSL', 
         'LIBRARY_SEARCH_PATHS' => '"${PODS_ROOT}/OpenSSL-Universal/lib-ios"' }
 
-  s.libraries = 'ssl', 'crypto'
-
   s.subspec 'Core' do |core|
     core.source_files = 'MIHCrypto/{Utils,Core}/*.{h,m,c}'
-    core.dependency 'OpenSSL-Universal', '~> 1.0.2.19'
+    core.dependency 'OpenSSL-Universal', '~> 1.1.171'
   end
 
   s.subspec 'Mathematics' do |ss|

--- a/MIHCrypto.podspec
+++ b/MIHCrypto.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |core|
     core.source_files = 'MIHCrypto/{Utils,Core}/*.{h,m,c}'
-    core.dependency 'OpenSSL-Universal', '~> 1.1.171'
+    core.dependency 'OpenSSL-Universal', '~> 1.1.180'
   end
 
   s.subspec 'Mathematics' do |ss|

--- a/MIHCrypto.xcodeproj/project.pbxproj
+++ b/MIHCrypto.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 				5F35130E18FC259F002BD9D9 /* Sources */,
 				5F35130F18FC259F002BD9D9 /* Frameworks */,
 				5F35131018FC259F002BD9D9 /* Resources */,
+				7D6E8E8A41A53E728FADB515 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -702,6 +703,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7D6E8E8A41A53E728FADB515 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MIHCryptoTests/Pods-MIHCryptoTests-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MIHCryptoTests/Pods-MIHCryptoTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A07FE50CF4403210D23AC355 /* [CP] Check Pods Manifest.lock */ = {

--- a/MIHCrypto/AES/MIHAESKeyFactory.m
+++ b/MIHCrypto/AES/MIHAESKeyFactory.m
@@ -17,8 +17,7 @@
 
 #import "MIHAESKeyFactory.h"
 #import "MIHAESKey.h"
-#import <openssl/aes.h>
-#import <openssl/rand.h>
+#import <OpenSSL/OpenSSL.h>
 
 @implementation MIHAESKeyFactory
 

--- a/MIHCrypto/DES/MIHDESKey+Internal.h
+++ b/MIHCrypto/DES/MIHDESKey+Internal.h
@@ -17,7 +17,7 @@
 
 #import "MIHDESKey.h"
 #import "MIHDESKeyFactory.h"
-#import <openssl/evp.h>
+#import <OpenSSL/OpenSSL.h>
 
 /**
  * These category on MIHDESKey contains an static helper which fetches the EVP_CIPHER for the passed MIHDESMode.

--- a/MIHCrypto/DES/MIHDESKey.m
+++ b/MIHCrypto/DES/MIHDESKey.m
@@ -135,20 +135,20 @@
         return nil;
     }
     
-    if (!EVP_DecryptInit(&decryptCtx, evpCipher, self.key.bytes, self.iv.bytes)) {
+    if (!EVP_DecryptInit(decryptCtx, evpCipher, self.key.bytes, self.iv.bytes)) {
         free(messageBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;
     }
     
-    if (!EVP_DecryptUpdate(&decryptCtx, messageBytes, (int *) &blockLength, cipherData.bytes, (int) cipherData.length)) {
+    if (!EVP_DecryptUpdate(decryptCtx, messageBytes, (int *) &blockLength, cipherData.bytes, (int) cipherData.length)) {
         free(messageBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;
     }
     messageBytesLength += blockLength;
     
-    if (!EVP_DecryptFinal(&decryptCtx, messageBytes + messageBytesLength, (int *) &blockLength)) {
+    if (!EVP_DecryptFinal(decryptCtx, messageBytes + messageBytesLength, (int *) &blockLength)) {
         free(messageBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;
@@ -176,20 +176,20 @@
         @throw [NSException outOfMemoryException];
     }
     
-    if (!EVP_EncryptInit(&encryptCtx, evpCipher, self.key.bytes, self.iv.bytes)) {
+    if (!EVP_EncryptInit(encryptCtx, evpCipher, self.key.bytes, self.iv.bytes)) {
         free(cipherBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;
     }
     
-    if (!EVP_EncryptUpdate(&encryptCtx, cipherBytes, (int *) &blockLength, messageData.bytes, (int)messageData.length)) {
+    if (!EVP_EncryptUpdate(encryptCtx, cipherBytes, (int *) &blockLength, messageData.bytes, (int)messageData.length)) {
         free(cipherBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;
     }
     cipherBytesLength += blockLength;
     
-    if (!EVP_EncryptFinal(&encryptCtx, cipherBytes + cipherBytesLength, (int *) &blockLength)) {
+    if (!EVP_EncryptFinal(encryptCtx, cipherBytes + cipherBytesLength, (int *) &blockLength)) {
         free(cipherBytes);
         if (error) *error = [NSError errorFromOpenSSL];
         return nil;

--- a/MIHCrypto/DES/MIHDESKey.m
+++ b/MIHCrypto/DES/MIHDESKey.m
@@ -21,12 +21,12 @@
 #import "NSString+MIHConversion.h"
 #import "MIHErrors.h"
 #import "MIHInternal.h"
-#import <openssl/evp.h>
+#import <OpenSSL/OpenSSL.h>
 
 @implementation MIHDESKey
 {
-    EVP_CIPHER_CTX encryptCtx;
-    EVP_CIPHER_CTX decryptCtx;
+    EVP_CIPHER_CTX *encryptCtx;
+    EVP_CIPHER_CTX *decryptCtx;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -47,6 +47,8 @@
         _key = [coder decodeObjectForKey:@"_key"];
         _iv = [coder decodeObjectForKey:@"_iv"];
         _mode = [coder decodeIntegerForKey:@"_mode"];
+        encryptCtx = EVP_CIPHER_CTX_new();
+        decryptCtx = EVP_CIPHER_CTX_new();
     }
     
     return self;
@@ -59,6 +61,8 @@
         _key = key;
         _iv = iv;
         _mode = mode;
+        encryptCtx = EVP_CIPHER_CTX_new();
+        decryptCtx = EVP_CIPHER_CTX_new();
     }
     
     return self;
@@ -99,6 +103,8 @@
                  _mode = [MIHDESKey modeFromModeName:modeName];
              }
          }];
+        encryptCtx = EVP_CIPHER_CTX_new();
+        decryptCtx = EVP_CIPHER_CTX_new();
     }
     
     return self;
@@ -244,6 +250,11 @@
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<MIHDESKey %@>", self.stringValue];
+}
+
+- (void)dealloc {
+    EVP_CIPHER_CTX_free(encryptCtx);
+    EVP_CIPHER_CTX_free(decryptCtx);
 }
 
 @end

--- a/MIHCrypto/DES/MIHDESKeyFactory.m
+++ b/MIHCrypto/DES/MIHDESKeyFactory.m
@@ -19,9 +19,7 @@
 #import "MIHDESKey.h"
 #import "MIHDESKey+Internal.h"
 #import "MIHInternal.h"
-#import <openssl/dsa.h>
-#import <openssl/evp.h>
-#import <openssl/rand.h>
+#import <OpenSSL/OpenSSL.h>
 
 @implementation MIHDESKeyFactory
 

--- a/MIHCrypto/EC/MIHEC.h
+++ b/MIHCrypto/EC/MIHEC.h
@@ -7,6 +7,4 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <openssl/ec.h>
-#import <openssl/ecdh.h>
-#import <openssl/ecdsa.h>
+#import <OpenSSL/OpenSSL.h>

--- a/MIHCrypto/EC/MIHECCurves.m
+++ b/MIHCrypto/EC/MIHECCurves.m
@@ -8,7 +8,7 @@
 
 #import "MIHECCurves.h"
 #import "MIHEC.h"
-#import <openssl/objects.h> // convert nid to sn.
+#import <OpenSSL/OpenSSL.h> // convert nid to sn.
 
 @interface MIHECCurve ()
 // maybe add flag that buildin_curve is ok?

--- a/MIHCrypto/EC/MIHECDigest.m
+++ b/MIHCrypto/EC/MIHECDigest.m
@@ -7,7 +7,7 @@
 //
 
 #import "MIHECDigest.h"
-#import <openssl/sha.h>
+#import <OpenSSL/OpenSSL.h>
 
 @implementation MIHECDigest__Constants
 + (NSNumber *)sha1 { return @(SHA_DIGEST_LENGTH); }

--- a/MIHCrypto/EC/MIHECPemSanitizer.m
+++ b/MIHCrypto/EC/MIHECPemSanitizer.m
@@ -79,7 +79,7 @@
     
     BOOL canConvertToPem = string != nil && [self isValidBase64String:string];
     if (canConvertToPem) {
-        __auto_type formattedString = [[[NSData alloc] initWithBase64Encoding:string] MIH_base64EncodedStringWithWrapWidth:64];
+        __auto_type formattedString = [[[NSData alloc] initWithBase64EncodedString:string options:0] MIH_base64EncodedStringWithWrapWidth:64];
         __auto_type result = @[beginHeader, formattedString, endHeader];
         return [[result componentsJoinedByString:@"\n"] stringByAppendingString:@"\n"];
     }

--- a/MIHCrypto/EC/MIHECPrivateKey.m
+++ b/MIHCrypto/EC/MIHECPrivateKey.m
@@ -56,7 +56,7 @@
 
 #import "MIHNSDataExtension.h"
 #import "MIHECSignature.h"
-#import <openssl/err.h>
+#import <OpenSSL/OpenSSL.h>
 @implementation MIHECPrivateKey (MIHPrivateKey)
 
 - (NSData *)encrypt:(NSData *)message error:(NSError *__autoreleasing *)error { return nil; }

--- a/MIHCrypto/EC/MIHECSignature.m
+++ b/MIHCrypto/EC/MIHECSignature.m
@@ -32,7 +32,7 @@
 }
 @end
 
-#import <openssl/err.h>
+#import <OpenSSL/OpenSSL.h>
 @implementation MIHECSignature (Conversion)
 + (ECDSA_SIG *)signatureFromData:(NSData *)data {
     __auto_type dataBytesCount = data.length;

--- a/MIHCrypto/MD5/MIHMessageDigest5.m
+++ b/MIHCrypto/MD5/MIHMessageDigest5.m
@@ -17,7 +17,7 @@
 
 #import "MIHMessageDigest5.h"
 #import "MIHInternal.h"
-#import <openssl/md5.h>
+#import <OpenSSL/OpenSSL.h>
 
 
 @implementation MIHMessageDigest5

--- a/MIHCrypto/Mathematics/MIHBigInteger+Factory.m
+++ b/MIHCrypto/Mathematics/MIHBigInteger+Factory.m
@@ -19,8 +19,7 @@
 #import "MIHBigInteger+Internal.h"
 #import "MIHBigIntegerRange.h"
 #import "MIHInternal.h"
-#include <openssl/bn.h>
-#include <openssl/rand.h>
+#include <OpenSSL/OpenSSL.h>
 
 static dispatch_block_t sMIHInitRANDOnce = ^() {
     RAND_poll();

--- a/MIHCrypto/Mathematics/MIHBigInteger.h
+++ b/MIHCrypto/Mathematics/MIHBigInteger.h
@@ -18,6 +18,26 @@
 #import "MIHNumber.h"
 #include <OpenSSL/OpenSSL.h>
 
+/** Added missing BN_LONG (was removed in newer OpenSSL versions) **/
+
+/*
+ * 64-bit processor with LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT_LONG
+#  define BN_LONG        long
+# endif
+
+/*
+ * 64-bit processor other than LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT
+#  define BN_LONG        long long
+# endif
+
+# ifdef THIRTY_TWO_BIT
+#  define BN_LONG        int
+# endif
+
 /**
  *  Class which wraps the functionality of OpenSSL BIGNUM data type.
  *  BIGNUM is a integer data type which can store numbers of unlimited size without loosing precision.
@@ -55,7 +75,7 @@
  *
  *  @return The newly-created MIHBigInteger instance.
  */
-- (id)initWithSignedInteger:(BN_ULONG)value;
+- (id)initWithSignedInteger:(BN_LONG)value;
 
 /**
  *  Initialises MIHBigInteger with the passed NSString which contains a decimal number as string.

--- a/MIHCrypto/Mathematics/MIHBigInteger.h
+++ b/MIHCrypto/Mathematics/MIHBigInteger.h
@@ -16,7 +16,7 @@
 //
 
 #import "MIHNumber.h"
-#import <openssl/bn.h>
+#include <OpenSSL/OpenSSL.h>
 
 /**
  *  Class which wraps the functionality of OpenSSL BIGNUM data type.
@@ -55,7 +55,7 @@
  *
  *  @return The newly-created MIHBigInteger instance.
  */
-- (id)initWithSignedInteger:(BN_LONG)value;
+- (id)initWithSignedInteger:(BN_ULONG)value;
 
 /**
  *  Initialises MIHBigInteger with the passed NSString which contains a decimal number as string.

--- a/MIHCrypto/Mathematics/MIHBigInteger.m
+++ b/MIHCrypto/Mathematics/MIHBigInteger.m
@@ -39,7 +39,7 @@
     return self;
 }
 
-- (id)initWithSignedInteger:(BN_LONG)value
+- (id)initWithSignedInteger:(BN_ULONG)value
 {
     self = [super init];
     if (self) {

--- a/MIHCrypto/Mathematics/MIHBigInteger.m
+++ b/MIHCrypto/Mathematics/MIHBigInteger.m
@@ -39,7 +39,7 @@
     return self;
 }
 
-- (id)initWithSignedInteger:(BN_ULONG)value
+- (id)initWithSignedInteger:(BN_LONG)value
 {
     self = [super init];
     if (self) {

--- a/MIHCrypto/Mathematics/MIHBigIntegerRange.h
+++ b/MIHCrypto/Mathematics/MIHBigIntegerRange.h
@@ -36,7 +36,7 @@
 /**
  *  Compares this `MIHBigIntegerRange with the passed `MIHBigIntegerRange`.
  *
- *  @param other `MIHBigIntegerRange` to compare with.
+ *  @param range `MIHBigIntegerRange` to compare with.
  *
  *  @return `YES` if the other `MIHBigIntegerRange` is equal to this one.
  */

--- a/MIHCrypto/RSA/MIHRSAPrivateKey+Internal.h
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey+Internal.h
@@ -16,7 +16,7 @@
 //
 
 #import "MIHRSAPrivateKey.h"
-
+#include <OpenSSL/OpenSSL.h>
 /**
  * These category on MIHRSAPrivateKey contains an initializer which should only get used by MIHRSAKeyFactory.
  *

--- a/MIHCrypto/RSA/MIHRSAPrivateKey+Internal.m
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey+Internal.m
@@ -24,7 +24,7 @@
 {
     self = [super init];
     if (self) {
-        CRYPTO_add(&rsa->references, 1, CRYPTO_LOCK_RSA);
+        RSA_up_ref(rsa);
         _rsa = rsa;
     }
 

--- a/MIHCrypto/RSA/MIHRSAPrivateKey.h
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.h
@@ -15,7 +15,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#include <openssl/rsa.h>
+#include <OpenSSL/OpenSSL.h>
 #import "MIHPrivateKey.h"
 
 /**

--- a/MIHCrypto/RSA/MIHRSAPrivateKey.m
+++ b/MIHCrypto/RSA/MIHRSAPrivateKey.m
@@ -17,8 +17,7 @@
 
 #import "MIHRSAPrivateKey.h"
 #import "MIHInternal.h"
-#include <openssl/pem.h>
-#include <openssl/md5.h>
+#include <OpenSSL/OpenSSL.h>
 @implementation MIHRSAPrivateKey
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -63,7 +62,7 @@
     MIHRSAPrivateKey *copy = [[[self class] allocWithZone:zone] init];
 
     if (copy != nil) {
-        CRYPTO_add(&_rsa->references, 1, CRYPTO_LOCK_RSA);
+        RSA_up_ref(_rsa);
         copy->_rsa = _rsa;
     }
 

--- a/MIHCrypto/RSA/MIHRSAPublicKey+Internal.m
+++ b/MIHCrypto/RSA/MIHRSAPublicKey+Internal.m
@@ -16,7 +16,7 @@
 //
 
 #import "MIHRSAPublicKey+Internal.h"
-#import <OpenSSL-Universal/openssl/evp.h>
+#import <OpenSSL/OpenSSL.h>
 
 @implementation MIHRSAPublicKey (Internal)
 
@@ -24,7 +24,7 @@
 {
     self = [super init];
     if (self) {
-        CRYPTO_add(&rsa->references, 1, CRYPTO_LOCK_RSA);
+        RSA_up_ref(rsa);
         _rsa = rsa;
     }
 

--- a/MIHCrypto/RSA/MIHRSAPublicKey.h
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.h
@@ -15,7 +15,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#include <openssl/rsa.h>
+#include <OpenSSL/OpenSSL.h>
 #import "MIHPublicKey.h"
 
 /**

--- a/MIHCrypto/RSA/MIHRSAPublicKey.m
+++ b/MIHCrypto/RSA/MIHRSAPublicKey.m
@@ -18,8 +18,7 @@
 #import "MIHRSAPublicKey.h"
 #import "MIHInternal.h"
 #import "NSData+MIHConversion.h"
-#include <openssl/pem.h>
-#include <openssl/md5.h>
+#include <OpenSSL/OpenSSL.h>
 
 @implementation MIHRSAPublicKey
 
@@ -72,7 +71,7 @@
     MIHRSAPublicKey *copy = [[[self class] allocWithZone:zone] init];
 
     if (copy != nil) {
-        CRYPTO_add(&_rsa->references, 1, CRYPTO_LOCK_RSA);
+        RSA_up_ref(_rsa);
         copy->_rsa = _rsa;
     }
 

--- a/MIHCrypto/SHA/MIHSecureHashAlgorithm.m
+++ b/MIHCrypto/SHA/MIHSecureHashAlgorithm.m
@@ -17,7 +17,7 @@
 
 #import "MIHSecureHashAlgorithm.h"
 #import "MIHInternal.h"
-#import <openssl/sha.h>
+#import <OpenSSL/OpenSSL.h>
 
 
 @implementation MIHSecureHashAlgorithm

--- a/MIHCrypto/SHA/MIHSecureHashAlgorithm256.m
+++ b/MIHCrypto/SHA/MIHSecureHashAlgorithm256.m
@@ -17,7 +17,7 @@
 
 #import "MIHSecureHashAlgorithm256.h"
 #import "MIHInternal.h"
-#import <openssl/sha.h>
+#import <OpenSSL/OpenSSL.h>
 
 
 @implementation MIHSecureHashAlgorithm256

--- a/MIHCrypto/SHA/MIHSecureHashAlgorithm384.m
+++ b/MIHCrypto/SHA/MIHSecureHashAlgorithm384.m
@@ -17,7 +17,7 @@
 
 #import "MIHSecureHashAlgorithm384.h"
 #import "MIHInternal.h"
-#import <openssl/sha.h>
+#import <OpenSSL/OpenSSL.h>
 
 
 @implementation MIHSecureHashAlgorithm384

--- a/MIHCrypto/SHA/MIHSecureHashAlgorithm512.m
+++ b/MIHCrypto/SHA/MIHSecureHashAlgorithm512.m
@@ -17,7 +17,7 @@
 
 #import "MIHSecureHashAlgorithm512.h"
 #import "MIHInternal.h"
-#import <openssl/sha.h>
+#import <OpenSSL/OpenSSL.h>
 
 
 @implementation MIHSecureHashAlgorithm512

--- a/MIHCrypto/Utils/MIHCryptoConfiguration.m
+++ b/MIHCrypto/Utils/MIHCryptoConfiguration.m
@@ -8,9 +8,7 @@
 
 #import "MIHCryptoConfiguration.h"
 #import "MIHErrors.h"
-#include <openssl/conf.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
+#include <OpenSSL/OpenSSL.h>
 
 @implementation MIHCryptoConfiguration
 

--- a/MIHCrypto/Utils/MIHInternal.m
+++ b/MIHCrypto/Utils/MIHInternal.m
@@ -17,8 +17,7 @@
 
 #import "MIHInternal.h"
 #import "MIHErrors.h"
-#include <openssl/err.h>
-#include <openssl/rand.h>
+#include <OpenSSL/OpenSSL.h>
 
 static dispatch_once_t loadErrorsOnce = 0;
 

--- a/MIHCrypto/Utils/NSData+MIHConversion.m
+++ b/MIHCrypto/Utils/NSData+MIHConversion.m
@@ -17,8 +17,7 @@
 
 #import "NSData+MIHConversion.h"
 #import "MIHInternal.h"
-#include <openssl/bio.h>
-#include <openssl/evp.h>
+#include <OpenSSL/OpenSSL.h>
 
 #pragma GCC diagnostic ignored "-Wselector"
 

--- a/MIHCrypto/Utils/NSData+MIHConversion.m
+++ b/MIHCrypto/Utils/NSData+MIHConversion.m
@@ -51,7 +51,7 @@
     
     if (![NSData instancesRespondToSelector:@selector(base64EncodedStringWithOptions:)])
     {
-        encoded = [self base64Encoding];
+        encoded = [self base64EncodedStringWithOptions: 0];
     }
     else
         
@@ -112,7 +112,7 @@
     
     if (![NSData instancesRespondToSelector:@selector(initWithBase64EncodedString:options:)])
     {
-        decoded = [[self alloc] initWithBase64Encoding:base64String];
+        decoded = [[self alloc] initWithBase64EncodedString:base64String options:0];
     }
     else
         

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 source 'https://cdn.cocoapods.org/'
-platform :osx, '10.9'
+platform :osx, '10.10'
 
 def all
-	pod 'OpenSSL-Universal', '~> 1.0.2.19'
+	pod 'OpenSSL-Universal', '~> 1.1.171'
 end
 
 target 'MIHCrypto' do

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://cdn.cocoapods.org/'
 platform :osx, '10.10'
 
 def all
-	pod 'OpenSSL-Universal', '~> 1.1.171'
+	pod 'OpenSSL-Universal', '~> 1.1.180'
 end
 
 target 'MIHCrypto' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,16 @@
 PODS:
-  - OpenSSL-Universal (1.0.2.19):
-    - OpenSSL-Universal/Static (= 1.0.2.19)
-  - OpenSSL-Universal/Static (1.0.2.19)
+  - OpenSSL-Universal (1.1.180)
 
 DEPENDENCIES:
-  - OpenSSL-Universal (~> 1.0.2.19)
+  - OpenSSL-Universal (~> 1.1.180)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - OpenSSL-Universal
 
 SPEC CHECKSUMS:
-  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
 
-PODFILE CHECKSUM: 3445187c09e657979b8cbfb3eb4dc3378e8d8774
+PODFILE CHECKSUM: 744e2a2987f71821891574225e02bb6eff2ca52d
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Universal-OpenSSL 1.1.X is a breaking change.. had to do a few adjustments:
1. updated minimum dependency version
2. EVP_CIPHER_CTX can't be used directly, using EVP_CIPHER_CTX_new.
3. Updated imports to #import <OpenSSL/OpenSSL.h> instead of directly importing files
4. Updated some deprecated functions (initWithBase64Encoding for example)
5. replace CRYPTO_add(&_rsa->references, 1, CRYPTO_LOCK_RSA); with RSA_up_ref

This change also fixes listing issue (https://github.com/hohl/MIHCrypto/issues/62), so now lint has no errors..